### PR TITLE
Fix requirements link parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Additional references:
 
 ## Installation
 
+Install Doorstop from source:
+
+Clone this repo and launch `pip install` inside of main repository folder:
+```sh
+pip install .
+```
+
 Install Doorstop with pip:
 
 ```sh

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -731,20 +731,19 @@ class Item(BaseFileObject):  # pylint: disable=R0902
         # Find child objects
         log.debug("finding item {}'s child objects...".format(self))
         for document2 in tree:
-            if document2.parent == document.prefix:
-                child_documents.append(document2)
-                # Search for child items unless we only need to find one
-                if not child_items or find_all:
-                    for item2 in document2:
-                        if self.uid in item2.links:
-                            if not item2.active:
-                                item2 = UnknownItem(item2.uid)
-                                log.warning(item2.exception)
-                                child_items.append(item2)
-                            else:
-                                child_items.append(item2)
-                                if not find_all and item2.active:
-                                    break
+            child_documents.append(document2)
+            # Search for child items unless we only need to find one
+            if not child_items or find_all:
+                for item2 in document2:
+                    if self.uid in item2.links:
+                        if not item2.active:
+                            item2 = UnknownItem(item2.uid)
+                            log.warning(item2.exception)
+                            child_items.append(item2)
+                        else:
+                            child_items.append(item2)
+                            if not find_all and item2.active:
+                                break
         # Display found links
         if child_items:
             if find_all:


### PR DESCRIPTION
This allows doorstop to maintain traceability on links between different prefixes (folders).